### PR TITLE
Refactor service clients for test/main separation

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -126,6 +126,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/src/main/java/com/taller/integration/client/ConsumerServiceClient.java
+++ b/integration-tests/src/main/java/com/taller/integration/client/ConsumerServiceClient.java
@@ -5,33 +5,18 @@ import io.restassured.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static io.restassured.RestAssured.given;
-
 @Component
 @RequiredArgsConstructor
 public class ConsumerServiceClient {
 
     private final IntegrationTestConfig config;
 
+    // Implementación stub para production/main module — las pruebas usan la clase en src/test
     public Response consumeApps(String nameForGreeting) {
-        return given()
-                .baseUri(config.getConsumerBaseUrl())
-                .pathParam("nameForGreeting", nameForGreeting)
-                .when()
-                .get("/consumeApps/{nameForGreeting}")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Este cliente es solo un stub en el código main. Use la clase de pruebas en src/test para integración.");
     }
 
     public Response healthCheck() {
-        return given()
-                .baseUri(config.getConsumerBaseUrl())
-                .when()
-                .get("/api/health")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Este cliente es solo un stub en el código main. Use la clase de pruebas en src/test para integración.");
     }
 }
-

--- a/integration-tests/src/main/java/com/taller/integration/client/MonitoringServiceClient.java
+++ b/integration-tests/src/main/java/com/taller/integration/client/MonitoringServiceClient.java
@@ -5,8 +5,6 @@ import io.restassured.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static io.restassured.RestAssured.given;
-
 @Component
 @RequiredArgsConstructor
 public class MonitoringServiceClient {
@@ -14,100 +12,10 @@ public class MonitoringServiceClient {
     private final IntegrationTestConfig config;
 
     public Response getServiceStatus() {
-        return given()
-                .baseUri(config.getMonitoringBaseUrl())
-                .when()
-                .get("/status")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response healthCheck() {
-        return given()
-                .baseUri(config.getMonitoringBaseUrl())
-                .when()
-                .get("/health")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 }
-package com.taller.integration.client;
-
-import com.taller.integration.config.IntegrationTestConfig;
-import com.taller.integration.dto.LoginRequest;
-import com.taller.integration.dto.UserRegistrationRequest;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
-import static io.restassured.RestAssured.given;
-
-@Component
-@RequiredArgsConstructor
-public class SecurityServiceClient {
-
-    private final IntegrationTestConfig config;
-
-    public Response registerUser(UserRegistrationRequest request) {
-        return given()
-                .baseUri(config.getSecurityBaseUrl())
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when()
-                .post("/api/users")
-                .then()
-                .extract()
-                .response();
-    }
-
-    public Response login(LoginRequest request) {
-        return given()
-                .baseUri(config.getSecurityBaseUrl())
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .extract()
-                .response();
-    }
-
-    public Response getUsers(String token, int page, int size) {
-        return given()
-                .baseUri(config.getSecurityBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .queryParam("page", page)
-                .queryParam("size", size)
-                .when()
-                .get("/api/users")
-                .then()
-                .extract()
-                .response();
-    }
-
-    public Response getUserById(String token, String userId) {
-        return given()
-                .baseUri(config.getSecurityBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get("/api/users/" + userId)
-                .then()
-                .extract()
-                .response();
-    }
-
-    public Response healthCheck() {
-        return given()
-                .baseUri(config.getSecurityBaseUrl())
-                .when()
-                .get("/api/health")
-                .then()
-                .extract()
-                .response();
-    }
-}
-

--- a/integration-tests/src/main/java/com/taller/integration/client/OrchestratorServiceClient.java
+++ b/integration-tests/src/main/java/com/taller/integration/client/OrchestratorServiceClient.java
@@ -2,12 +2,9 @@ package com.taller.integration.client;
 
 import com.taller.integration.config.IntegrationTestConfig;
 import com.taller.integration.dto.NotificationRequest;
-import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import static io.restassured.RestAssured.given;
 
 @Component
 @RequiredArgsConstructor
@@ -16,72 +13,26 @@ public class OrchestratorServiceClient {
     private final IntegrationTestConfig config;
 
     public Response createNotification(NotificationRequest request, String token) {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when()
-                .post("/api/notifications")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response getNotifications(String token, int page, int size) {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .queryParam("page", page)
-                .queryParam("size", size)
-                .when()
-                .get("/api/notifications")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response getNotificationById(String token, String notificationId) {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get("/api/notifications/" + notificationId)
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response getChannels(String token) {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get("/api/notifications/channels")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response getTemplates(String token) {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get("/api/notifications/templates")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response healthCheck() {
-        return given()
-                .baseUri(config.getOrchestratorBaseUrl())
-                .when()
-                .get("/api/health")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 }
-

--- a/integration-tests/src/main/java/com/taller/integration/client/SaludoServiceClient.java
+++ b/integration-tests/src/main/java/com/taller/integration/client/SaludoServiceClient.java
@@ -5,8 +5,6 @@ import io.restassured.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static io.restassured.RestAssured.given;
-
 @Component
 @RequiredArgsConstructor
 public class SaludoServiceClient {
@@ -14,25 +12,10 @@ public class SaludoServiceClient {
     private final IntegrationTestConfig config;
 
     public Response getGreeting(String nombre, String token) {
-        return given()
-                .baseUri(config.getSaludoBaseUrl())
-                .header("Authorization", token)
-                .queryParam("nombre", nombre)
-                .when()
-                .get("/saludo")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 
     public Response healthCheck() {
-        return given()
-                .baseUri(config.getSaludoBaseUrl())
-                .when()
-                .get("/api/health")
-                .then()
-                .extract()
-                .response();
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
     }
 }
-

--- a/integration-tests/src/main/java/com/taller/integration/client/SecurityServiceClient.java
+++ b/integration-tests/src/main/java/com/taller/integration/client/SecurityServiceClient.java
@@ -1,0 +1,35 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import com.taller.integration.dto.LoginRequest;
+import com.taller.integration.dto.UserRegistrationRequest;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response registerUser(UserRegistrationRequest request) {
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
+    }
+
+    public Response login(LoginRequest request) {
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
+    }
+
+    public Response getUsers(String token, int page, int size) {
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
+    }
+
+    public Response getUserById(String token, String userId) {
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
+    }
+
+    public Response healthCheck() {
+        throw new UnsupportedOperationException("Stub en main; las pruebas usan la implementación en src/test que depende de RestAssured.");
+    }
+}

--- a/integration-tests/src/main/java/com/taller/integration/dto/NotificationRequest.java
+++ b/integration-tests/src/main/java/com/taller/integration/dto/NotificationRequest.java
@@ -16,20 +16,3 @@ public class NotificationRequest {
     private Map<String, Object> parameters;
     private String message;
 }
-package com.taller.integration.dto;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class UserRegistrationRequest {
-    private String username;
-    private String email;
-    private String password;
-    private String firstName;
-    private String lastName;
-}
-

--- a/integration-tests/src/main/java/com/taller/integration/dto/UserRegistrationRequest.java
+++ b/integration-tests/src/main/java/com/taller/integration/dto/UserRegistrationRequest.java
@@ -1,0 +1,17 @@
+package com.taller.integration.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegistrationRequest {
+    private String username;
+    private String email;
+    private String password;
+    private String firstName;
+    private String lastName;
+}
+

--- a/integration-tests/src/test/java/com/taller/integration/client/ConsumerServiceClient.java
+++ b/integration-tests/src/test/java/com/taller/integration/client/ConsumerServiceClient.java
@@ -1,0 +1,37 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+@RequiredArgsConstructor
+public class ConsumerServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response consumeApps(String nameForGreeting) {
+        return given()
+                .baseUri(config.getConsumerBaseUrl())
+                .pathParam("nameForGreeting", nameForGreeting)
+                .when()
+                .get("/consumeApps/{nameForGreeting}")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response healthCheck() {
+        return given()
+                .baseUri(config.getConsumerBaseUrl())
+                .when()
+                .get("/api/health")
+                .then()
+                .extract()
+                .response();
+    }
+}
+

--- a/integration-tests/src/test/java/com/taller/integration/client/MonitoringServiceClient.java
+++ b/integration-tests/src/test/java/com/taller/integration/client/MonitoringServiceClient.java
@@ -1,0 +1,36 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+@RequiredArgsConstructor
+public class MonitoringServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response getServiceStatus() {
+        return given()
+                .baseUri(config.getMonitoringBaseUrl())
+                .when()
+                .get("/status")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response healthCheck() {
+        return given()
+                .baseUri(config.getMonitoringBaseUrl())
+                .when()
+                .get("/health")
+                .then()
+                .extract()
+                .response();
+    }
+}
+

--- a/integration-tests/src/test/java/com/taller/integration/client/OrchestratorServiceClient.java
+++ b/integration-tests/src/test/java/com/taller/integration/client/OrchestratorServiceClient.java
@@ -1,0 +1,87 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import com.taller.integration.dto.NotificationRequest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+@RequiredArgsConstructor
+public class OrchestratorServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response createNotification(NotificationRequest request, String token) {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/notifications")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getNotifications(String token, int page, int size) {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .queryParam("page", page)
+                .queryParam("size", size)
+                .when()
+                .get("/api/notifications")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getNotificationById(String token, String notificationId) {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/notifications/" + notificationId)
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getChannels(String token) {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/notifications/channels")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getTemplates(String token) {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/notifications/templates")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response healthCheck() {
+        return given()
+                .baseUri(config.getOrchestratorBaseUrl())
+                .when()
+                .get("/api/health")
+                .then()
+                .extract()
+                .response();
+    }
+}
+

--- a/integration-tests/src/test/java/com/taller/integration/client/SaludoServiceClient.java
+++ b/integration-tests/src/test/java/com/taller/integration/client/SaludoServiceClient.java
@@ -1,0 +1,38 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+@RequiredArgsConstructor
+public class SaludoServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response getGreeting(String nombre, String token) {
+        return given()
+                .baseUri(config.getSaludoBaseUrl())
+                .header("Authorization", token)
+                .queryParam("nombre", nombre)
+                .when()
+                .get("/saludo")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response healthCheck() {
+        return given()
+                .baseUri(config.getSaludoBaseUrl())
+                .when()
+                .get("/api/health")
+                .then()
+                .extract()
+                .response();
+    }
+}
+

--- a/integration-tests/src/test/java/com/taller/integration/client/SecurityServiceClient.java
+++ b/integration-tests/src/test/java/com/taller/integration/client/SecurityServiceClient.java
@@ -1,0 +1,77 @@
+package com.taller.integration.client;
+
+import com.taller.integration.config.IntegrationTestConfig;
+import com.taller.integration.dto.LoginRequest;
+import com.taller.integration.dto.UserRegistrationRequest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityServiceClient {
+
+    private final IntegrationTestConfig config;
+
+    public Response registerUser(UserRegistrationRequest request) {
+        return given()
+                .baseUri(config.getSecurityBaseUrl())
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/users")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response login(LoginRequest request) {
+        return given()
+                .baseUri(config.getSecurityBaseUrl())
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/auth/login")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getUsers(String token, int page, int size) {
+        return given()
+                .baseUri(config.getSecurityBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .queryParam("page", page)
+                .queryParam("size", size)
+                .when()
+                .get("/api/users")
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response getUserById(String token, String userId) {
+        return given()
+                .baseUri(config.getSecurityBaseUrl())
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/users/" + userId)
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response healthCheck() {
+        return given()
+                .baseUri(config.getSecurityBaseUrl())
+                .when()
+                .get("/api/health")
+                .then()
+                .extract()
+                .response();
+    }
+}
+


### PR DESCRIPTION
Moved RestAssured-based service client implementations to src/test and replaced main module clients with stubs throwing UnsupportedOperationException. This enables integration tests to use real HTTP clients while keeping production code free of test dependencies. Also split UserRegistrationRequest into its own file and added rest-assured dependency to pom.xml.